### PR TITLE
Fix Svelte 5 compatibility issues in editor

### DIFF
--- a/editor/src/lib/components/DataGrid.svelte
+++ b/editor/src/lib/components/DataGrid.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
 	import { Grid } from '@svar-ui/svelte-grid';
-	import {
-		flatModels,
-		categories,
-		updateModel,
-		validationErrors
-	} from '$lib/stores/data.svelte';
-	import type { FlatModel, Benchmark } from '$lib/types';
+	import { store, updateModel } from '$lib/stores/data.svelte';
+	import type { FlatModel } from '$lib/types';
 
 	interface Props {
 		theme?: 'light' | 'dark';
@@ -100,7 +95,7 @@
 		];
 
 		// Add benchmark columns from categories
-		for (const category of categories) {
+		for (const category of store.categories) {
 			for (const benchmark of category.benchmarks) {
 				cols.push({
 					id: benchmark.id,
@@ -116,7 +111,7 @@
 					},
 					css: (row: FlatModel) => {
 						const value = row[benchmark.id] as number | null;
-						const hasError = validationErrors.some(
+						const hasError = store.validationErrors.some(
 							(e) => e.modelId === row.id && e.field === benchmark.id
 						);
 
@@ -159,7 +154,7 @@
 				key.startsWith('pricing_') ||
 				key === 'speed' ||
 				key === 'latency' ||
-				categories.some((c) => c.benchmarks.some((b) => b.id === key))
+				store.categories.some((c) => c.benchmarks.some((b) => b.id === key))
 			) {
 				if (value === '' || value === null) {
 					parsedValue = null;
@@ -189,9 +184,9 @@
 	}
 
 	export function exportToCsv(): void {
-		// Manual CSV export since SVAR might not have built-in
+		// Manual CSV export
 		const headers = columns.map((c: any) => c.header).join(',');
-		const rows = flatModels.map((row) =>
+		const rows = store.flatModels.map((row) =>
 			columns
 				.map((c: any) => {
 					const val = row[c.id as keyof FlatModel];
@@ -213,15 +208,15 @@
 </script>
 
 <div class="grid-wrapper" class:dark={theme === 'dark'}>
-	<Grid data={flatModels} {columns} {init} />
+	<Grid data={store.flatModels} {columns} {init} />
 </div>
 
 <style>
 	.grid-wrapper {
 		width: 100%;
 		height: 100%;
-		--wx-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-			Arial, sans-serif;
+		--wx-font-family:
+			-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 		--wx-font-size: 13px;
 	}
 

--- a/editor/src/lib/components/StatsPanel.svelte
+++ b/editor/src/lib/components/StatsPanel.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		getStats,
-		meta,
-		validationErrors,
-		history,
-		models
-	} from '$lib/stores/data.svelte';
+	import { store, getStats } from '$lib/stores/data.svelte';
 
 	const stats = $derived(getStats());
 
@@ -21,14 +15,17 @@
 
 	// Get recent history entries (last 10)
 	const recentHistory = $derived(
-		[...history].reverse().slice(0, 10).map((entry) => {
-			const model = models.find((m) => m.id === entry.modelId);
-			return {
-				...entry,
-				modelName: model?.name || entry.modelId,
-				time: new Date(entry.timestamp).toLocaleTimeString()
-			};
-		})
+		[...store.history]
+			.reverse()
+			.slice(0, 10)
+			.map((entry) => {
+				const model = store.models.find((m) => m.id === entry.modelId);
+				return {
+					...entry,
+					modelName: model?.name || entry.modelId,
+					time: new Date(entry.timestamp).toLocaleTimeString()
+				};
+			})
 	);
 </script>
 
@@ -36,16 +33,16 @@
 	<!-- Metadata -->
 	<div class="card">
 		<h4 class="card-title">Data Info</h4>
-		{#if meta}
+		{#if store.meta}
 			<table class="stats-table">
 				<tbody>
 					<tr>
 						<td>Version</td>
-						<td>{meta.version}</td>
+						<td>{store.meta.version}</td>
 					</tr>
 					<tr>
 						<td>Last Update</td>
-						<td>{new Date(meta.last_update).toLocaleString()}</td>
+						<td>{new Date(store.meta.last_update).toLocaleString()}</td>
 					</tr>
 					<tr>
 						<td>Total Models</td>
@@ -102,20 +99,20 @@
 	</div>
 
 	<!-- Validation Errors -->
-	{#if validationErrors.length > 0}
+	{#if store.validationErrors.length > 0}
 		<div class="card validation-card">
-			<h4 class="card-title">Validation Errors ({validationErrors.length})</h4>
+			<h4 class="card-title">Validation Errors ({store.validationErrors.length})</h4>
 			<ul class="validation-list">
-				{#each validationErrors.slice(0, 10) as error}
+				{#each store.validationErrors.slice(0, 10) as error}
 					<li>
 						<span class="error-model">{error.modelName}</span>
 						<span class="error-field">{error.field}</span>
 						<span class="error-message">{error.message}</span>
 					</li>
 				{/each}
-				{#if validationErrors.length > 10}
+				{#if store.validationErrors.length > 10}
 					<li class="more-errors">
-						... and {validationErrors.length - 10} more
+						... and {store.validationErrors.length - 10} more
 					</li>
 				{/if}
 			</ul>

--- a/editor/src/routes/+layout.svelte
+++ b/editor/src/routes/+layout.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import '../app.css';
 	import { onMount } from 'svelte';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
 
 	let theme = $state<'light' | 'dark'>('light');
 
@@ -20,14 +27,6 @@
 		localStorage.setItem('editor-theme', theme);
 		document.documentElement.classList.toggle('dark', theme === 'dark');
 	}
-
-	// Export for children to use
-	const layoutContext = {
-		get theme() {
-			return theme;
-		},
-		toggleTheme
-	};
 </script>
 
 <svelte:head>
@@ -35,4 +34,4 @@
 	<meta name="description" content="Data editor for Showdown LLM Rankings" />
 </svelte:head>
 
-<slot {layoutContext} />
+{@render children()}

--- a/editor/src/routes/+page.svelte
+++ b/editor/src/routes/+page.svelte
@@ -3,17 +3,12 @@
 	import DataGrid from '$lib/components/DataGrid.svelte';
 	import Toolbar from '$lib/components/Toolbar.svelte';
 	import StatsPanel from '$lib/components/StatsPanel.svelte';
-	import {
-		loadData,
-		isLoading,
-		notifications,
-		removeNotification
-	} from '$lib/stores/data.svelte';
+	import { store, loadData, removeNotification } from '$lib/stores/data.svelte';
 
 	let theme = $state<'light' | 'dark'>('light');
 	let sidebarOpen = $state(true);
 	let selectedModelId = $state<string | null>(null);
-	let gridComponent: DataGrid;
+	let gridComponent = $state<DataGrid | null>(null);
 
 	onMount(async () => {
 		// Load theme preference
@@ -60,7 +55,7 @@
 </script>
 
 <div class="editor-container">
-	{#if isLoading}
+	{#if store.isLoading}
 		<div class="loading-screen">
 			<div class="loading-spinner"></div>
 			<p>Loading data...</p>
@@ -90,7 +85,7 @@
 
 	<!-- Notifications -->
 	<div class="notifications-container">
-		{#each notifications as notification (notification.id)}
+		{#each store.notifications as notification (notification.id)}
 			<div class="notification {notification.type}" role="alert">
 				<span>{notification.message}</span>
 				<button


### PR DESCRIPTION
- Refactor store to use getter pattern for state exports
- Fix deprecated slot warning with {@render children()}
- Add tabindex to dialog for a11y compliance
- Format code with prettier