### PR TITLE
Add Claude Haiku 4.5 and Gemini 2.5 Flash Lite

### DIFF
--- a/data/showdown.json
+++ b/data/showdown.json
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"version": "2025.12.23",
-		"last_update": "2025-12-23T00:00:00Z",
+		"last_update": "2025-12-23T12:00:00Z",
 		"schema_version": "1.0"
 	},
 	"models": [
@@ -179,6 +179,50 @@
 				"mmmlu": 84.5,
 				"lmarena_en_elo": 1431,
 				"lmarena_zh_elo": 1375
+			}
+		},
+		{
+			"id": "claude-haiku-4-5-20251001",
+			"name": "Claude Haiku 4.5",
+			"provider": "Anthropic",
+			"type": "proprietary",
+			"release_date": "2025-10-01",
+			"pricing": {
+				"input_per_1m": 1.0,
+				"output_per_1m": 5.0,
+				"average_per_1m": 3.0
+			},
+			"performance": {
+				"output_speed_tps": 150,
+				"latency_ttft_ms": 600,
+				"source": "https://artificialanalysis.ai"
+			},
+			"editor_notes": "Fast, efficient model optimized for low-latency tasks. Achieves 73.3% on SWE-bench at one-third the cost of Sonnet 4 and 2x the speed. Strong at coding and computer use with first Haiku model to support extended thinking.",
+			"benchmark_scores": {
+				"swe_bench": 73.3,
+				"terminal_bench": 41.0,
+				"lmarena_coding_elo": null,
+				"live_code_bench": null,
+				"gpqa_diamond": null,
+				"aime": 3.5,
+				"arc_agi_2": null,
+				"lmarena_hard_elo": null,
+				"bfcl": null,
+				"tau_bench": null,
+				"osworld": 50.7,
+				"webdev_arena_elo": 1353,
+				"lmarena_creative_elo": null,
+				"lmarena_if_elo": null,
+				"math_500": null,
+				"gsm8k": null,
+				"lmarena_math_elo": null,
+				"mathvista": null,
+				"mmmu": 73.2,
+				"lmarena_vision_elo": null,
+				"mmlu": null,
+				"mmmlu": null,
+				"lmarena_en_elo": null,
+				"lmarena_zh_elo": null
 			}
 		},
 		{
@@ -663,6 +707,50 @@
 				"mmmlu": 84.2,
 				"lmarena_en_elo": 1454,
 				"lmarena_zh_elo": 1497
+			}
+		},
+		{
+			"id": "gemini-2.5-flash-lite",
+			"name": "Gemini 2.5 Flash Lite",
+			"provider": "Google",
+			"type": "proprietary",
+			"release_date": "2025-07-22",
+			"pricing": {
+				"input_per_1m": 0.1,
+				"output_per_1m": 0.4,
+				"average_per_1m": 0.25
+			},
+			"performance": {
+				"output_speed_tps": 393,
+				"latency_ttft_ms": 290,
+				"source": "https://artificialanalysis.ai"
+			},
+			"editor_notes": "Fastest and most cost-efficient Gemini 2.5 model. Optimized for high-volume, latency-sensitive tasks with 50% reduction in output tokens. Strong performance at ultra-low cost ($0.10/$0.40).",
+			"benchmark_scores": {
+				"swe_bench": null,
+				"terminal_bench": null,
+				"lmarena_coding_elo": null,
+				"live_code_bench": null,
+				"gpqa_diamond": 64.6,
+				"aime": null,
+				"arc_agi_2": null,
+				"lmarena_hard_elo": null,
+				"bfcl": null,
+				"tau_bench": null,
+				"osworld": null,
+				"webdev_arena_elo": null,
+				"lmarena_creative_elo": null,
+				"lmarena_if_elo": null,
+				"math_500": 92.6,
+				"gsm8k": null,
+				"lmarena_math_elo": null,
+				"mathvista": null,
+				"mmmu": 72.9,
+				"lmarena_vision_elo": null,
+				"mmlu": 84.5,
+				"mmmlu": null,
+				"lmarena_en_elo": null,
+				"lmarena_zh_elo": null
 			}
 		},
 		{


### PR DESCRIPTION
- Added Claude Haiku 4.5 (claude-haiku-4-5-20251001)
  - Released 2025-10-01
  - Pricing: $1/$5 per million tokens
  - SWE-bench: 73.3%, Terminal-bench: 41%, OSWorld: 50.7%
  - Fast, efficient model optimized for low-latency coding tasks

- Added Gemini 2.5 Flash Lite (gemini-2.5-flash-lite)
  - Released 2025-07-22
  - Pricing: $0.10/$0.40 per million tokens (most cost-efficient)
  - Speed: 393 TPS, Latency: 290ms
  - MMLU: 84.5%, GPQA: 64.6%, MMMU: 72.9%, MATH-500: 92.6%

Updated meta timestamp to 2025-12-23T12:00:00Z