### PR TITLE
Improve multi-word search filtering

### DIFF
--- a/src/lib/ranking.test.ts
+++ b/src/lib/ranking.test.ts
@@ -851,6 +851,25 @@ describe('filterModels', () => {
 		expect(filtered[0].model.id).toBe('model1');
 	});
 
+	it('should filter by multi-word search query across fields', () => {
+		const model1: Model = {
+			...mockModel,
+			id: 'model1',
+			name: 'GPT-4',
+			provider: 'OpenAI'
+		};
+		const model2: Model = { ...mockModel, id: 'model2', name: 'Claude', provider: 'Anthropic' };
+		const categories: Category[] = [mockCategory];
+		const ranked = rankModels([model1, model2], categories);
+
+		const filtered = filterModels(ranked, {
+			searchQuery: 'openai gpt'
+		});
+
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].model.id).toBe('model1');
+	});
+
 	it('should filter by aka (alternative names)', () => {
 		const model1: Model = {
 			...mockModel,

--- a/src/lib/ranking.ts
+++ b/src/lib/ranking.ts
@@ -1260,6 +1260,7 @@ export function filterModels(
 	}
 ): RankedModel[] {
 	const query = filters.searchQuery?.toLowerCase().trim();
+	const queryTerms = query ? query.split(/\s+/) : null;
 
 	// Create Sets for O(1) lookups
 	const providerSet = filters.providers?.length ? new Set(filters.providers) : null;
@@ -1286,18 +1287,14 @@ export function filterModels(
 		const model = ranked.model;
 
 		// Search query filter
-		if (query) {
-			let matches =
-				model.name.toLowerCase().includes(query) || model.provider.toLowerCase().includes(query);
+		if (queryTerms && queryTerms.length > 0) {
+			const searchableText = [
+				model.name.toLowerCase(),
+				model.provider.toLowerCase(),
+				...(model.aka ? model.aka.map((a) => a.toLowerCase()) : [])
+			].join(' ');
 
-			if (!matches && model.aka) {
-				for (const alias of model.aka) {
-					if (alias.toLowerCase().includes(query)) {
-						matches = true;
-						break;
-					}
-				}
-			}
+			const matches = queryTerms.every((term) => searchableText.includes(term));
 
 			if (!matches) continue;
 		}


### PR DESCRIPTION
Improves the search functionality within the application to properly support multi-word search queries.

Previously, a user typing `openai gpt-4` in the search bar would find nothing because the query checked for exact substring matches in individual fields (`name`, `provider`, or `aka`).

This PR splits the query into individual space-separated terms and ensures that **every term** appears somewhere across a model's combined name, provider, and aka text. This drastically improves the UX when searching for models by provider and model name simultaneously.

A new test case was added to `src/lib/ranking.test.ts` to ensure this behavior is correct and won't regress.

---
*PR created automatically by Jules for task [1045621418172484078](https://jules.google.com/task/1045621418172484078) started by @insign*