### PR TITLE
Refactor: Migrate deprecated $app/stores to modern $app/state in UI

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext, onMount } from 'svelte';
 	import { untrack } from 'svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import SimpleMultiSelect from '$lib/components/SimpleMultiSelect.svelte';
 	import RangeSlider from '$lib/components/RangeSlider.svelte';
@@ -100,7 +100,7 @@
 
 	// Load favorites and column visibility from localStorage (only once on mount)
 	onMount(() => {
-		const searchParams = $page.url.searchParams;
+		const searchParams = page.url.searchParams;
 
 		if (searchParams.has('sortBy')) {
 			sortBy = searchParams.get('sortBy')!;
@@ -218,7 +218,7 @@
 		untrack(() => {
 			// Using the built-in URLSearchParams, but casting as any or using window.URLSearchParams to avoid Svelte compiler warning
 			// eslint-disable-next-line svelte/prefer-svelte-reactivity
-			const params = new URLSearchParams($page.url.searchParams.toString());
+			const params = new URLSearchParams(page.url.searchParams.toString());
 
 			if (currentSortBy !== 'coding') params.set('sortBy', currentSortBy);
 			else params.delete('sortBy');
@@ -260,11 +260,11 @@
 			}
 
 			const query = params.toString();
-			const to = query ? `?${query}` : $page.url.pathname;
+			const to = query ? `?${query}` : page.url.pathname;
 
 			// Compare strings directly since URL objects can have empty search vs no search
 			const currentSearch =
-				$page.url.search === '' && query === '' ? true : $page.url.search === `?${query}`;
+				page.url.search === '' && query === '' ? true : page.url.search === `?${query}`;
 
 			if (!currentSearch) {
 				goto(to, { replaceState: true, keepFocus: true, noScroll: true });


### PR DESCRIPTION
Migra o store deprecado `$app/stores` para o moderno `$app/state` do SvelteKit 2.12+.

Essa mudança substitui a inscrição via store `$page.url` por acesso direto `page.url` na camada de roteamento Svelte 5 do `+page.svelte`. Isso adiciona valor real ao melhorar diretamente a manutenibilidade, atualizando a stack de reatividade e removendo avisos de linter antigos. Nenhuma dependência externa ou nova ferramenta foi adicionada, e nenhum comportamento da aplicação foi alterado ou quebrado (testes unitários e build pré-commit passaram com sucesso).

---
*PR created automatically by Jules for task [8607820355926773619](https://jules.google.com/task/8607820355926773619) started by @insign*