### PR TITLE
Fix unknown performance metrics sorting to the top

### DIFF
--- a/src/lib/ranking.test.ts
+++ b/src/lib/ranking.test.ts
@@ -812,6 +812,36 @@ describe('sortModels', () => {
 		const sortedDesc = sortModels(ranked, 'name', 'desc');
 		expect(sortedDesc[0].model.name).toBe('Beta');
 	});
+
+	it('should handle unknown (0) speed and latency by treating them as null (pushing to bottom)', () => {
+		const model1: Model = {
+			...mockModel,
+			id: 'm1',
+			performance: { ...mockModel.performance, output_speed_tps: 50, latency_ttft_ms: 200 }
+		};
+		const model2: Model = {
+			...mockModel,
+			id: 'm2',
+			performance: { ...mockModel.performance, output_speed_tps: 0, latency_ttft_ms: 0 }
+		};
+		const model3: Model = {
+			...mockModel,
+			id: 'm3',
+			performance: { ...mockModel.performance, output_speed_tps: 100, latency_ttft_ms: 100 }
+		};
+
+		const ranked = rankModels([model1, model2, model3], [mockCategory]);
+
+		const sortedSpeedAsc = sortModels(ranked, 'speed', 'asc');
+		expect(sortedSpeedAsc[0].model.id).toBe('m1');
+		expect(sortedSpeedAsc[1].model.id).toBe('m3');
+		expect(sortedSpeedAsc[2].model.id).toBe('m2');
+
+		const sortedLatencyAsc = sortModels(ranked, 'latency', 'asc');
+		expect(sortedLatencyAsc[0].model.id).toBe('m3');
+		expect(sortedLatencyAsc[1].model.id).toBe('m1');
+		expect(sortedLatencyAsc[2].model.id).toBe('m2');
+	});
 });
 
 describe('filterModels', () => {

--- a/src/lib/ranking.ts
+++ b/src/lib/ranking.ts
@@ -1206,10 +1206,10 @@ export function sortModels(
 			getValue = (item) => item.model.pricing.average_per_1m;
 			break;
 		case 'speed':
-			getValue = (item) => item.model.performance.output_speed_tps;
+			getValue = (item) => item.model.performance.output_speed_tps || null;
 			break;
 		case 'latency':
-			getValue = (item) => item.model.performance.latency_ttft_ms;
+			getValue = (item) => item.model.performance.latency_ttft_ms || null;
 			break;
 		case 'release_date':
 			getValue = (item) => item.model.release_date;


### PR DESCRIPTION
Fixes a UX bug where models with unknown (0) speed and latency would sort to the top when sorting in ascending order.

By coercing `0` values to `null` during sorting for `speed` and `latency`, these unknown values are appropriately pushed to the bottom of the list rather than appearing as the "fastest" models. A test has been added to `ranking.test.ts` to ensure this behavior does not regress.

---
*PR created automatically by Jules for task [4681410518839320561](https://jules.google.com/task/4681410518839320561) started by @insign*