### PR TITLE
Update ARC-AGI-2 score for GPT-4.5

### DIFF
--- a/data/showdown.json
+++ b/data/showdown.json
@@ -1,7 +1,7 @@
 {
 	"meta": {
-		"version": "2026.04.12",
-		"last_update": "2026-04-12T15:00:00Z",
+		"version": "2026.04.13",
+		"last_update": "2026-04-13T15:00:00Z",
 		"schema_version": "1.0"
 	},
 	"models": [
@@ -766,7 +766,7 @@
 			"editor_notes": "Significant upgrade over 4o with improved factual accuracy and reasoning. Leading in factual accuracy on SimpleQA during release.",
 			"benchmark_scores": {
 				"aime": 75,
-				"arc_agi_2": 7.5,
+				"arc_agi_2": 10.3,
 				"bfcl": 78.5,
 				"gpqa_diamond": 65,
 				"lmarena_en_elo": 1447,


### PR DESCRIPTION
This PR updates the ARC-AGI-2 benchmark score for GPT-4.5 to 10.3% based on the latest data from the ARCPrize leaderboard, ensuring the benchmark data remains accurate and verifiable.

The ARC-AGI-2 score for GPT-4.5 (Base LLM) was checked via the arcprize.org leaderboard using the project's web fetch tool and proxy.

Modifications:
- `gpt-4.5-preview-2025-02-27` ARC-AGI-2 score changed from 7.5 to 10.3
- `meta.last_update` and `meta.version` bumped to indicate the data change

---
*PR created automatically by Jules for task [12123661642558217161](https://jules.google.com/task/12123661642558217161) started by @insign*