### PR TITLE
refactor: migrate deprecated `$app/stores` to modern `$app/state`

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext, onMount } from 'svelte';
 	import { untrack } from 'svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import SimpleMultiSelect from '$lib/components/SimpleMultiSelect.svelte';
 	import RangeSlider from '$lib/components/RangeSlider.svelte';
@@ -100,7 +100,7 @@
 
 	// Load favorites and column visibility from localStorage (only once on mount)
 	onMount(() => {
-		const searchParams = $page.url.searchParams;
+		const searchParams = page.url.searchParams;
 
 		if (searchParams.has('sortBy')) {
 			sortBy = searchParams.get('sortBy')!;
@@ -218,7 +218,7 @@
 		untrack(() => {
 			// Using the built-in URLSearchParams, but casting as any or using window.URLSearchParams to avoid Svelte compiler warning
 			// eslint-disable-next-line svelte/prefer-svelte-reactivity
-			const params = new URLSearchParams($page.url.searchParams.toString());
+			const params = new URLSearchParams(page.url.searchParams.toString());
 
 			if (currentSortBy !== 'coding') params.set('sortBy', currentSortBy);
 			else params.delete('sortBy');
@@ -260,11 +260,11 @@
 			}
 
 			const query = params.toString();
-			const to = query ? `?${query}` : $page.url.pathname;
+			const to = query ? `?${query}` : page.url.pathname;
 
 			// Compare strings directly since URL objects can have empty search vs no search
 			const currentSearch =
-				$page.url.search === '' && query === '' ? true : $page.url.search === `?${query}`;
+				page.url.search === '' && query === '' ? true : page.url.search === `?${query}`;
 
 			if (!currentSearch) {
 				goto(to, { replaceState: true, keepFocus: true, noScroll: true });


### PR DESCRIPTION
Migrates deprecated `$app/stores` import to `$app/state` in the main page component.

The previous implementation relied on `$app/stores` which is deprecated in Svelte 5 and SvelteKit 2.12+. This change updates the page to use `import { page } from '$app/state'` and removes the `$` prefix from all `page` references, seamlessly integrating with Svelte 5's new reactivity model (`untrack`, etc.) and resolving potential linter warnings for reactive tracking outside boundaries. No functional changes have been introduced; this is purely a modernization to support long-term SvelteKit maintainability.

---
*PR created automatically by Jules for task [4386353796072929764](https://jules.google.com/task/4386353796072929764) started by @insign*