### PR TITLE
Fix sorting of 'Unknown' speed and latency values

### DIFF
--- a/src/lib/ranking.test.ts
+++ b/src/lib/ranking.test.ts
@@ -23,7 +23,7 @@ import {
 	applySweBenchFamilyBridge,
 	DEFAULT_SUPERIORITY_RATIO
 } from './ranking.js';
-import type { Model, Category, Benchmark } from './types.js';
+import type { Model, Category, Benchmark, RankedModel } from './types.js';
 
 // Test fixtures
 const mockBenchmark: Benchmark = {
@@ -811,6 +811,50 @@ describe('sortModels', () => {
 
 		const sortedDesc = sortModels(ranked, 'name', 'desc');
 		expect(sortedDesc[0].model.name).toBe('Beta');
+	});
+
+	it('should sort unknown (0) speed and latency to the end', () => {
+		const model1: Model = {
+			...mockModel,
+			id: 'm1',
+			performance: { ...mockModel.performance, output_speed_tps: 0, latency_ttft_ms: 0 }
+		};
+		const model2: Model = {
+			...mockModel,
+			id: 'm2',
+			performance: { ...mockModel.performance, output_speed_tps: 50, latency_ttft_ms: 200 }
+		};
+		const model3: Model = {
+			...mockModel,
+			id: 'm3',
+			performance: { ...mockModel.performance, output_speed_tps: 100, latency_ttft_ms: 100 }
+		};
+
+		const ranked: RankedModel[] = [
+			{ rank: 1, model: model1, overallScore: null, categoryScores: {}, coverage: 0 },
+			{ rank: 2, model: model2, overallScore: null, categoryScores: {}, coverage: 0 },
+			{ rank: 3, model: model3, overallScore: null, categoryScores: {}, coverage: 0 }
+		];
+
+		const sortedSpeedAsc = sortModels(ranked, 'speed', 'asc');
+		expect(sortedSpeedAsc[0].model.id).toBe('m2');
+		expect(sortedSpeedAsc[1].model.id).toBe('m3');
+		expect(sortedSpeedAsc[2].model.id).toBe('m1');
+
+		const sortedSpeedDesc = sortModels(ranked, 'speed', 'desc');
+		expect(sortedSpeedDesc[0].model.id).toBe('m3');
+		expect(sortedSpeedDesc[1].model.id).toBe('m2');
+		expect(sortedSpeedDesc[2].model.id).toBe('m1');
+
+		const sortedLatencyAsc = sortModels(ranked, 'latency', 'asc');
+		expect(sortedLatencyAsc[0].model.id).toBe('m3');
+		expect(sortedLatencyAsc[1].model.id).toBe('m2');
+		expect(sortedLatencyAsc[2].model.id).toBe('m1');
+
+		const sortedLatencyDesc = sortModels(ranked, 'latency', 'desc');
+		expect(sortedLatencyDesc[0].model.id).toBe('m2');
+		expect(sortedLatencyDesc[1].model.id).toBe('m3');
+		expect(sortedLatencyDesc[2].model.id).toBe('m1');
 	});
 });
 

--- a/src/lib/ranking.ts
+++ b/src/lib/ranking.ts
@@ -1206,10 +1206,16 @@ export function sortModels(
 			getValue = (item) => item.model.pricing.average_per_1m;
 			break;
 		case 'speed':
-			getValue = (item) => item.model.performance.output_speed_tps;
+			getValue = (item) =>
+				item.model.performance.output_speed_tps === 0
+					? null
+					: item.model.performance.output_speed_tps;
 			break;
 		case 'latency':
-			getValue = (item) => item.model.performance.latency_ttft_ms;
+			getValue = (item) =>
+				item.model.performance.latency_ttft_ms === 0
+					? null
+					: item.model.performance.latency_ttft_ms;
 			break;
 		case 'release_date':
 			getValue = (item) => item.model.release_date;


### PR DESCRIPTION
Fix sorting of 'Unknown' (0) values for speed and latency to the end of the list, improving sorting reliability and UX.

This PR addresses an issue where models with an "Unknown" (0) value for speed or latency would falsely rank as the fastest model when sorting in ascending order. By correctly interpreting `0` as a `null` value during the sorting phase, unknown values are now appropriately pushed to the bottom of the list, providing a much more accurate and intuitive user experience.

Files modified:
- `src/lib/ranking.ts`: Adjusted `sortModels` `getValue` extraction for `speed` and `latency` to convert `0` to `null`.
- `src/lib/ranking.test.ts`: Added unit tests verifying ascending and descending sorting behavior for `0` speed and latency values.

---
*PR created automatically by Jules for task [3454530011516060403](https://jules.google.com/task/3454530011516060403) started by @insign*